### PR TITLE
[TC-5] review-checklist: cohesion (hl/ + HDF5Examples/)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,45 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
+# Last matching pattern takes the most precedence.
 
-# These owners will be the default owners for everything in the repo.
-* @lrknox @derobins @fortnern @jhendersonHDF @qkoziol @vchoi-hdfgroup @bmribler @glennsong09 @mattjala @brtnfld @mkitti
+# Global fallback — fires only for files not covered by a more specific rule
+# below. Keep this list small; add specific path rules instead of expanding it.
+* @fortnern
 
-# Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches javascript files, only these owners
-# will be requested to review.
-/fortran/         @brtnfld @derobins @epourmal
-/java/            @jhendersonHDF @mattjala
-# The HDF Group website needs to be updated to reflect any changes made here.
-/.github/.well-known @lkurz @loricooperhdf
+# ── Language bindings ─────────────────────────────────────────────────────────
+/fortran/             @brtnfld
+/java/                @jhendersonHDF @mattjala
+/c++/                 @bmribler @glennsong09
+
+# ── Core C library ────────────────────────────────────────────────────────────
+/src/                 @fortnern @jhendersonHDF @mattjala @vchoi-hdfgroup @glennsong09
+/src/H5FDsubfiling/  @jhendersonHDF
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+/test/                @fortnern @jhendersonHDF @glennsong09
+/testpar/             @jhendersonHDF @brtnfld
+
+# ── High-level API ────────────────────────────────────────────────────────────
+/hl/                  @brtnfld @mattjala
+
+# ── Tools ─────────────────────────────────────────────────────────────────────
+/tools/               @jhendersonHDF @mattjala
+
+# ── Examples ──────────────────────────────────────────────────────────────────
+/HDF5Examples/        @brtnfld @jhendersonHDF
+
+# ── Build system ──────────────────────────────────────────────────────────────
+/CMakeLists.txt       @lrknox @jhendersonHDF
+/CMakePresets.json    @lrknox @jhendersonHDF
+*.cmake               @lrknox @jhendersonHDF
+/config/              @lrknox @jhendersonHDF
+
+# ── Documentation ─────────────────────────────────────────────────────────────
+/docs/                @lrknox @glennsong09
+/release_docs/        @lrknox @glennsong09
+
+# ── CI / GitHub Actions ───────────────────────────────────────────────────────
+/.github/             @lrknox @jhendersonHDF
+
+# The HDF Group website verification — must stay in sync with hdfgroup.org
+/.github/.well-known  @lkurz

--- a/.github/workflows/review-checklist.yml
+++ b/.github/workflows/review-checklist.yml
@@ -1,0 +1,366 @@
+name: Review Checklist
+
+# Posts a per-area sign-off checklist on every PR and auto-checks each item
+# when one of that area's designated owners submits an approval.
+#
+# Reviewer lists are derived entirely from .github/CODEOWNERS — no duplication.
+# To add an area or change owners, edit only CODEOWNERS.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [develop]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  checklist:
+    runs-on: ubuntu-latest
+    # Only run on PRs targeting develop from within the same repo (not forks).
+    # For review events, only run on approvals targeting develop.
+    if: |
+      github.event.pull_request.base.ref == 'develop' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'approved'))
+
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = '<!-- hdf5-review-checklist-v1 -->';
+            const { owner, repo } = context.repo;
+            const pr_number = context.payload.pull_request.number;
+
+            // ----------------------------------------------------------------
+            // Configuration
+            //
+            // LINE_THRESHOLD: lines changed within a single area at or above
+            //   which the change is considered complex → first (senior) owner
+            //   in CODEOWNERS is always assigned.
+            //
+            // PUBLIC_HEADER: files matching this pattern are always treated as
+            //   complex regardless of line count — any change to the public or
+            //   developer API surface warrants the senior owner.
+            // ----------------------------------------------------------------
+            const LINE_THRESHOLD  = 300;   // default for all areas
+            const AREA_THRESHOLDS = {      // per-area overrides
+              '/test/': 500,               // test files are verbose; raise bar for senior
+            };
+            const PUBLIC_HEADER   = /public\.h$|develop\.h$/;
+
+            // ----------------------------------------------------------------
+            // 1. Parse CODEOWNERS into a list of { pattern, label, owners }
+            //
+            // Rules:
+            //  - Skip blank lines and lines starting with #
+            //  - Skip the global wildcard (*) — it covers everything and
+            //    would make every PR require every reviewer
+            //  - Owners are the @-prefixed tokens after the pattern
+            //  - Label is derived from the pattern path for display
+            // ----------------------------------------------------------------
+            const { data: coData } = await github.rest.repos.getContent({
+              owner, repo, path: '.github/CODEOWNERS',
+            });
+            const coText = Buffer.from(coData.content, 'base64').toString('utf-8');
+
+            function labelFromPattern(pattern) {
+              // /fortran/ → "fortran", /.github/.well-known → ".github/.well-known"
+              return pattern.replace(/^\//, '').replace(/\/$/, '') || pattern;
+            }
+
+            // Returns true if `file` (repo-relative, no leading slash) matches
+            // a CODEOWNERS-style gitignore pattern.
+            function matchesPattern(file, pattern) {
+              let p = pattern;
+
+              // Strip leading slash — CODEOWNERS anchors to root with it,
+              // but GitHub API paths have no leading slash
+              if (p.startsWith('/')) p = p.slice(1);
+
+              // Directory pattern: /fortran/ → matches fortran/<anything>
+              if (p.endsWith('/')) return file.startsWith(p);
+
+              // Glob pattern: convert * and ** to regex equivalents
+              if (p.includes('*')) {
+                const re = new RegExp(
+                  '^' +
+                  p.replace(/\./g, '\\.').split('**').map(s => s.replace(/\*/g, '[^/]*')).join('.*') +
+                  '($|/)'
+                );
+                return re.test(file);
+              }
+
+              // Plain path: exact match or directory prefix
+              return file === p || file.startsWith(p + '/');
+            }
+
+            const areas = [];
+            const allCodeOwners = new Set(); // every owner named anywhere in CODEOWNERS
+            for (const rawLine of coText.split('\n')) {
+              const line = rawLine.trim();
+              if (!line || line.startsWith('#')) continue;
+
+              const tokens  = line.split(/\s+/);
+              const pattern = tokens[0];
+              const owners  = tokens.slice(1)
+                                    .filter(t => t.startsWith('@'))
+                                    .map(t => t.slice(1)); // strip @
+
+              owners.forEach(o => allCodeOwners.add(o));
+
+              // Skip the global catch-all — it would fire on every file
+              if (pattern === '*') continue;
+              if (owners.length === 0) continue;
+
+              areas.push({
+                pattern,
+                label: labelFromPattern(pattern),
+                owners,
+              });
+            }
+
+            if (areas.length === 0) {
+              core.info('No path-specific rules found in CODEOWNERS — skipping checklist.');
+              return;
+            }
+
+            // ----------------------------------------------------------------
+            // 2. Collect all changed files with line counts.
+            //    Keeps the full file objects so per-area line totals can be
+            //    used to decide whether auto-assignment is warranted.
+            // ----------------------------------------------------------------
+            const changedFileData = [];
+            for (let page = 1; ; page++) {
+              const { data } = await github.rest.pulls.listFiles({
+                owner, repo, pull_number: pr_number, per_page: 100, page,
+              });
+              changedFileData.push(...data);
+              if (data.length < 100) break;
+            }
+
+            // ----------------------------------------------------------------
+            // 3. Find which CODEOWNERS areas are touched by this PR, and
+            //    total the lines changed within each area.
+            // ----------------------------------------------------------------
+            const touchedAreas = areas
+              .map(area => {
+                const areaFiles = changedFileData.filter(f =>
+                  matchesPattern(f.filename, area.pattern)
+                );
+                return {
+                  ...area,
+                  linesChanged: areaFiles.reduce((n, f) => n + f.changes, 0),
+                };
+              })
+              .filter(area => area.linesChanged > 0);
+
+            if (touchedAreas.length === 0) {
+              core.info('No CODEOWNERS-tracked areas changed — skipping checklist.');
+              return;
+            }
+
+            // ----------------------------------------------------------------
+            // 4. Determine current approvals.
+            //    Track latest review state per user so a subsequent
+            //    "request changes" cancels an earlier approval.
+            // ----------------------------------------------------------------
+            const allReviews = [];
+            for (let page = 1; ; page++) {
+              const { data } = await github.rest.pulls.listReviews({
+                owner, repo, pull_number: pr_number, per_page: 100, page,
+              });
+              allReviews.push(...data);
+              if (data.length < 100) break;
+            }
+
+            const latestStateByUser = {};
+            for (const review of allReviews) {
+              latestStateByUser[review.user.login] = review.state;
+            }
+            const approvedUsers = new Set(
+              Object.entries(latestStateByUser)
+                .filter(([, state]) => state === 'APPROVED')
+                .map(([login]) => login)
+            );
+
+            // ----------------------------------------------------------------
+            // 5. Fetch current PR state (requested reviewers).
+            //    Done outside the PR-only block so the checklist can also
+            //    show who is assigned when triggered by a review event.
+            // ----------------------------------------------------------------
+            const { data: prData } = await github.rest.pulls.get({
+              owner, repo, pull_number: pr_number,
+            });
+            const requestedReviewers = new Set(
+              prData.requested_reviewers.map(r => r.login)
+            );
+
+            // ----------------------------------------------------------------
+            // 6. For each touched area pick the ONE owner with the fewest
+            //    open review requests in this repo right now, then request
+            //    only that person. This load-balances across owners without
+            //    needing persistent state.
+            //
+            //    Skipped entirely if an area owner is already requested
+            //    (manual assignment or a previous run) — don't override.
+            //    Only runs on pull_request events, not review submissions.
+            // ----------------------------------------------------------------
+            if (context.eventName !== 'pull_request_review') {
+              const prAuthor = context.payload.pull_request.user.login;
+
+              // Assign the PR author only if they are a code owner.
+              // External contributors (not in CODEOWNERS) get no auto-assignee.
+              if (allCodeOwners.has(prAuthor)) {
+                try {
+                  await github.rest.issues.addAssignees({
+                    owner, repo, issue_number: pr_number, assignees: [prAuthor],
+                  });
+                  core.info(`Assigned PR to author ${prAuthor} (is a code owner)`);
+                } catch (e) {
+                  core.warning(`Could not assign PR to author: ${e.message}`);
+                }
+              } else {
+                core.info(`Author ${prAuthor} is not a code owner — skipping assignee`);
+              }
+
+              async function pendingReviewCount(username) {
+                const { data } = await github.rest.search.issuesAndPullRequests({
+                  q: `is:pr is:open review-requested:${username} repo:${owner}/${repo}`,
+                  per_page: 1,
+                });
+                return data.total_count;
+              }
+
+              async function selectReviewer(owners) {
+                const candidates = owners.filter(u => u !== prAuthor);
+                if (candidates.length === 0) return null;
+                if (candidates.length === 1) return candidates[0];
+
+                const counts = await Promise.all(
+                  candidates.map(async u => ({ u, n: await pendingReviewCount(u) }))
+                );
+                counts.sort((a, b) => a.n - b.n || candidates.indexOf(a.u) - candidates.indexOf(b.u));
+                core.info(`Review load for [${candidates.join(', ')}]: ${counts.map(c => `${c.u}=${c.n}`).join(', ')} → assigning ${counts[0].u}`);
+                return counts[0].u;
+              }
+
+              const selected = new Set();
+              for (const area of touchedAreas) {
+                if (area.owners.some(o => requestedReviewers.has(o))) {
+                  core.info(`Area "${area.label}" already has an owner assigned — skipping.`);
+                  continue;
+                }
+
+                // Cohesion: if someone already assigned to this PR also owns
+                // this area, reuse them. Prevents e.g. src/ going to @mattjala
+                // while test/ independently picks @fortnern — the same person
+                // should review related areas wherever the owner lists overlap.
+                const cohesionPick = [...selected].find(
+                  u => area.owners.includes(u) && u !== prAuthor
+                );
+                if (cohesionPick) {
+                  requestedReviewers.add(cohesionPick); // already in selected
+                  core.info(`Area "${area.label}": reusing ${cohesionPick} for cohesion`);
+                  continue;
+                }
+
+                // A change is "complex" if it hits the line threshold OR
+                // touches a public/developer API header in this area.
+                const threshold = AREA_THRESHOLDS[area.pattern] ?? LINE_THRESHOLD;
+                const touchesPublicHeader = changedFileData.some(f =>
+                  matchesPattern(f.filename, area.pattern) && PUBLIC_HEADER.test(f.filename)
+                );
+                const isComplex = area.linesChanged >= threshold || touchesPublicHeader;
+
+                let pick;
+                if (isComplex) {
+                  // Complex change: always assign the first (senior) owner in
+                  // CODEOWNERS, regardless of their current review load.
+                  pick = area.owners.find(u => u !== prAuthor) ?? null;
+                  const reason = touchesPublicHeader ? 'public header modified' : `${area.linesChanged} lines ≥ ${threshold}`;
+                  core.info(`Area "${area.label}" is complex (${reason}) — primary owner: ${pick}`);
+                } else {
+                  // Routine change: assign whoever has the lightest review load.
+                  pick = await selectReviewer(area.owners);
+                  core.info(`Area "${area.label}": ${area.linesChanged} lines (< ${threshold}), no public headers — load-balanced pick: ${pick}`);
+                }
+
+                if (pick) {
+                  selected.add(pick);
+                  requestedReviewers.add(pick);
+                }
+              }
+
+              if (selected.size > 0) {
+                try {
+                  await github.rest.pulls.requestReviewers({
+                    owner, repo, pull_number: pr_number,
+                    reviewers: [...selected],
+                  });
+                } catch (e) {
+                  core.warning(`Could not request reviewers: ${e.message}`);
+                }
+              }
+            }
+
+            // ----------------------------------------------------------------
+            // 7. Build the checklist body.
+            //    Each row shows the specific owner assigned for that area:
+            //    - pending:   the owner currently in requested_reviewers
+            //    - signed off: the owner who approved
+            //    This avoids listing all owners (bystander effect) while
+            //    still making clear who is responsible for each area.
+            // ----------------------------------------------------------------
+            const rows = touchedAreas.map(area => {
+              const approver  = area.owners.find(o => approvedUsers.has(o));
+              const assigned  = approver ?? area.owners.find(o => requestedReviewers.has(o));
+              const signedOff = !!approver;
+              const box       = signedOff ? 'x' : ' ';
+              const tick      = signedOff ? ' ✅' : '';
+              const mention   = assigned ? ` — @${assigned}` : '';
+              return `- [${box}] **${area.label}**${tick}${mention}`;
+            });
+
+            const allDone = rows.every(r => r.includes('[x]'));
+            const summary = allDone
+              ? '> ✅ All areas have been signed off.'
+              : '> ⏳ Waiting for sign-off on all areas listed above.';
+
+            const body = [
+              MARKER,
+              '## Review Checklist',
+              '',
+              'This PR touches the following areas. Each needs at least one',
+              'sign-off from its listed owners before merging — an approval',
+              'covering only one area does **not** satisfy the others.',
+              '',
+              ...rows,
+              '',
+              summary,
+            ].join('\n');
+
+            // ----------------------------------------------------------------
+            // 8. Create or update the checklist comment (idempotent via marker)
+            // ----------------------------------------------------------------
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: pr_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+              core.info(`Updated checklist comment #${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr_number, body,
+              });
+              core.info('Created checklist comment');
+            }

--- a/HDF5Examples/test_checklist_tc5.txt
+++ b/HDF5Examples/test_checklist_tc5.txt
@@ -1,0 +1,2 @@
+TC-5: review-checklist action test file — cohesion test (HDF5Examples/).
+Safe to delete after testing is complete.

--- a/hl/test_checklist_tc5.txt
+++ b/hl/test_checklist_tc5.txt
@@ -1,0 +1,2 @@
+TC-5: review-checklist action test file — cohesion test (hl/).
+Safe to delete after testing is complete.


### PR DESCRIPTION
**Test case TC-5** — two areas with overlapping owner lists. Tests the cohesion logic: once a reviewer is picked for the first area, they are reused for subsequent areas where they appear in the owner list, rather than issuing a second independent load-balanced pick.

**Touched areas:**
- `hl/` — owned by `@brtnfld @mattjala`
- `HDF5Examples/` — owned by `@brtnfld @jhendersonHDF`

**Expected behaviour:**
- Checklist posted with two rows: `hl`, `HDF5Examples`
- `brtnfld` assigned as PR assignee (author is a code owner)
- For `hl/`: author (`brtnfld`) filtered out → `mattjala` picked (load-balanced)
- For `HDF5Examples/`: `brtnfld` filtered out; `mattjala` is NOT in its owner list → no cohesion reuse; `jhendersonHDF` picked (load-balanced)
- Two separate reviewer requests (mattjala and jhendersonHDF) — cohesion only fires when the same person is in *both* areas' owner lists

Safe to close and delete branch after review.